### PR TITLE
Update base image in Dockerfiles

### DIFF
--- a/setup/dbaas/docker/Dockerfile.redis
+++ b/setup/dbaas/docker/Dockerfile.redis
@@ -57,7 +57,7 @@ RUN ./autogen.sh && \
 #&& make test
 
 
-FROM nexus3.o-ran-sc.org:10004/o-ran-sc/bldr-alpine3-go:6-a3.11-rmr3 as build-env
+FROM nexus3.o-ran-sc.org:10002/o-ran-sc/bldr-alpine3-go:2.0.0 as build-env
 
 RUN apk add cpputest
 COPY ./redismodule /redismodule

--- a/setup/e2/RIC-E2-TERMINATION/Dockerfile
+++ b/setup/e2/RIC-E2-TERMINATION/Dockerfile
@@ -20,7 +20,7 @@
 #   This source code is part of the near-RT RIC (RAN Intelligent Controller)
 #   platform project (RICP).
 #
-FROM nexus3.o-ran-sc.org:10004/o-ran-sc/bldr-ubuntu18-c-go:9-u18.04 as ubuntu
+FROM nexus3.o-ran-sc.org:10002/o-ran-sc/bldr-ubuntu18-c-go:1.9.0 as ubuntu
 
 WORKDIR /opt/e2/
 

--- a/setup/e2mgr/E2Manager/Dockerfile
+++ b/setup/e2mgr/E2Manager/Dockerfile
@@ -20,7 +20,7 @@
 #   platform project (RICP).
 #
 
-FROM nexus3.o-ran-sc.org:10004/o-ran-sc/bldr-ubuntu18-c-go:9-u18.04 as ubuntu
+FROM nexus3.o-ran-sc.org:10002/o-ran-sc/bldr-ubuntu18-c-go:1.9.0 as ubuntu
 
 WORKDIR /opt/E2Manager
 COPY . .

--- a/setup/e2mgr/tools/RoutingManagerSimulator/Dockerfile
+++ b/setup/e2mgr/tools/RoutingManagerSimulator/Dockerfile
@@ -16,7 +16,7 @@
 #
 ##############################################################################
 
-FROM nexus3.o-ran-sc.org:10004/o-ran-sc/bldr-ubuntu18-c-go:9-u18.04 as ubuntu
+FROM nexus3.o-ran-sc.org:10002/o-ran-sc/bldr-ubuntu18-c-go:1.9.0 as ubuntu
 
 WORKDIR /opt/rmsimulator
 COPY . . 


### PR DESCRIPTION
Hi,
The tag of Docker image and port of the repo used in Dockerfile don't exist any more.
This PR updates these two elements.