### PR TITLE
Fix delivery of indication message

### DIFF
--- a/setup/xapp-sm-connector/src/agent_connector.cc
+++ b/setup/xapp-sm-connector/src/agent_connector.cc
@@ -104,7 +104,7 @@ std::string find_agent_ip_from_gnb(unsigned char* gnb_id_trans) {
 
 
 // send through socket
-int send_socket(char* buf, std::string dest_ip) {
+int send_socket(char* buf, size_t payload_size, std::string dest_ip) {
 
   int control_sckfd = -1;
 
@@ -126,8 +126,7 @@ int send_socket(char* buf, std::string dest_ip) {
 
   // const size_t max_size = 512;
   // char buf[max_size] = "Hello, Server!";  // store the data in a buffer
-  size_t data_size = strlen(buf);
-  int sent_size = send(control_sckfd ,buf, data_size, 0);
+  int sent_size = send(control_sckfd ,buf, payload_size, 0);
 
   if(sent_size < 0) { // the send returns a size of -1 in case of errors
       std::cout <<  "ERROR: SEND to agent " << dest_ip << std::endl;

--- a/setup/xapp-sm-connector/src/agent_connector.cc
+++ b/setup/xapp-sm-connector/src/agent_connector.cc
@@ -126,7 +126,7 @@ int send_socket(char* buf, size_t payload_size, std::string dest_ip) {
 
   // const size_t max_size = 512;
   // char buf[max_size] = "Hello, Server!";  // store the data in a buffer
-  int sent_size = send(control_sckfd ,buf, payload_size, 0);
+  int sent_size = send(control_sckfd, buf, payload_size, 0);
 
   if(sent_size < 0) { // the send returns a size of -1 in case of errors
       std::cout <<  "ERROR: SEND to agent " << dest_ip << std::endl;

--- a/setup/xapp-sm-connector/src/agent_connector.hpp
+++ b/setup/xapp-sm-connector/src/agent_connector.hpp
@@ -27,6 +27,6 @@ extern std::map<std::string, std::string> agentIp_gnbId;
 int open_control_socket_agent(const char* dest_ip, const int dest_port);
 void close_control_socket_agent(void);
 std::string find_agent_ip_from_gnb(unsigned char* gnb_id);
-int send_socket(char* buf, std::string dest_ip);
+int send_socket(char* buf, size_t payload_size, std::string dest_ip);
 
 #endif

--- a/setup/xapp-sm-connector/src/xapp-mgmt/msgs_proc.cc
+++ b/setup/xapp-sm-connector/src/xapp-mgmt/msgs_proc.cc
@@ -271,7 +271,7 @@ uint8_t procRicIndication(E2AP_PDU_t *e2apMsg, transaction_identifier gnb_id)
 				}
 				case 26:  // RIC indication message
 				{
-					int payload_size = ricIndication->protocolIEs.list.array[idx]-> \
+					size_t payload_size = ricIndication->protocolIEs.list.array[idx]-> \
 																		 value.choice.RICindicationMessage.size;
 
 
@@ -283,7 +283,7 @@ uint8_t procRicIndication(E2AP_PDU_t *e2apMsg, transaction_identifier gnb_id)
 
 					// send payload to agent
 					std::string agent_ip = find_agent_ip_from_gnb(gnb_id);
-					send_socket(payload, agent_ip);
+					send_socket(payload, payload_size, agent_ip);
 
 					break;
 				}


### PR DESCRIPTION
xapp-sm-connector now sends entire indication message to the connected xApp. Previously only first Byte of the message was sent.

@Thecave3 